### PR TITLE
feat: Add colorful dice setting and default colors for standard rpg dice

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -151,6 +151,7 @@ interface DiceRollerSettings {
     renderer: boolean;
     renderAllDice: boolean;
     renderTime: number;
+    colorfulDice: boolean,
     diceColor: string;
     textColor: string;
     showLeafOnStartup: boolean;
@@ -177,6 +178,7 @@ export const DEFAULT_SETTINGS: DiceRollerSettings = {
     renderer: false,
     renderAllDice: false,
     renderTime: 2000,
+    colorfulDice: false,
     diceColor: "#202020",
     textColor: "#ffffff",
     showLeafOnStartup: true,

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -311,6 +311,21 @@ export default class SettingTab extends PluginSettingTab {
                     });
             });
 
+        new Setting(containerEl)
+            .setName("Use Colorful Dice")
+            .setDesc("Rendered dice will be varied colors based on the dice type. This will override manually set dice and text colors.")
+            .addToggle((t) => {
+                t.setValue(this.plugin.data.colorfulDice);
+                t.onChange(async (v) => {
+                    this.plugin.data.colorfulDice = v;
+                    await this.plugin.saveSettings();
+
+                    this.plugin.app.workspace.trigger(
+                        "dice-roller:update-colors"
+                    );
+                });
+            });
+
         const diceColor = new Setting(containerEl)
             .setName("Dice Base Color")
             .setDesc("Rendered dice will be this color.");

--- a/src/view/renderer.ts
+++ b/src/view/renderer.ts
@@ -760,10 +760,18 @@ class LocalWorld {
 class DiceFactory extends Component {
     dice: Record<string, DiceGeometry> = {};
     get colors() {
+        const diceColor = this.plugin.data.diceColor;
+        const textColor = this.plugin.data.textColor;
+
+        // If we want colorful dice then just use the default colors in the geometry
+        if (this.plugin.data.colorfulDice) {
+            return undefined
+        }
+
         return {
-            diceColor: this.plugin.data.diceColor,
-            textColor: this.plugin.data.textColor
-        };
+            diceColor,
+            textColor,
+        }
     }
     constructor(
         public width: number,

--- a/src/view/renderer/geometries.ts
+++ b/src/view/renderer/geometries.ts
@@ -450,7 +450,7 @@ class D20DiceGeometry extends DiceGeometry {
 
     mass = 400;
 
-    constructor(w: number, h: number, options = DEFAULT_DICE_OPTIONS) {
+    constructor(w: number, h: number, options = { diceColor: "#171120", textColor: "#FF0000"}) {
         super(w, h, options);
 
         let t = (1 + Math.sqrt(5)) / 2;
@@ -495,7 +495,7 @@ class D12DiceGeometry extends DiceGeometry {
     scaleFactor = 0.9;
     values = [...Array(12).keys()];
     margin = 1;
-    constructor(w: number, h: number, options = DEFAULT_DICE_OPTIONS) {
+    constructor(w: number, h: number, options = { diceColor: "#7339BE", textColor: "#FFFFFF" }) {
         super(w, h, options);
 
         let p = (1 + Math.sqrt(5)) / 2;
@@ -557,7 +557,7 @@ class D10DiceGeometry extends DiceGeometry {
     scaleFactor = 0.9;
     values = [...Array(10).keys()];
     margin = 1;
-    constructor(w: number, h: number, options = DEFAULT_DICE_OPTIONS) {
+    constructor(w: number, h: number, options = { diceColor: "#c74749", textColor: "#FFFFFF" }) {
         super(w, h, options);
         for (let i = 0, b = 0; i < 10; ++i, b += (Math.PI * 2) / 10) {
             this.vertices.push([
@@ -603,7 +603,7 @@ class D100DiceGeometry extends DiceGeometry {
     scaleFactor = 0.9;
     values = [...Array(10).keys()];
     margin = 1;
-    constructor(w: number, h: number, options = DEFAULT_DICE_OPTIONS) {
+    constructor(w: number, h: number, options = { diceColor: "#7a2c2d", textColor: "#FFFFFF" }) {
         super(w, h, options);
         for (let i = 0, b = 0; i < 10; ++i, b += (Math.PI * 2) / 10) {
             this.vertices.push([
@@ -644,6 +644,9 @@ class D8DiceGeometry extends DiceGeometry {
     scaleFactor = 1;
     values = [...Array(8).keys()];
     margin = 1.2;
+    constructor(w: number, h: number, options = { diceColor: "#5eb0c5", textColor: "#FFFFFF" }) {
+        super(w, h, options);
+    }
 }
 
 class D6DiceGeometry extends DiceGeometry {
@@ -673,6 +676,9 @@ class D6DiceGeometry extends DiceGeometry {
     sides = 6;
     margin = 1.0;
     values = [...Array(6).keys()];
+    constructor(w: number, h: number, options = { diceColor: "#d68316", textColor: "#FFFFFF" }) {
+        super(w, h, options);
+    }
 }
 class FudgeDiceGeometry extends DiceGeometry {
     mass = 300;
@@ -731,6 +737,10 @@ class D4DiceGeometry extends DiceGeometry {
     ];
     faceTexts = this.d4FaceTexts[0];
     values = [...Array(4).keys()];
+
+    constructor(w: number, h: number, options = { diceColor: "#93b139", textColor: "#FFFFFF" }) {
+        super(w, h, options);
+    }
 
     getMaterials() {
         let materials: MeshPhongMaterial[] = [];


### PR DESCRIPTION
# Overview
First off, I love the plugin. One helpful thing for me is being able to differentiate dice by color. So this PR adds in that functionality.
- Adds a new boolean setting allowing users to turn on and off "colorful" dice
- Adds default colors to standard RPG dice (d4-d20)

![Screenshot 2023-07-14 at 12 34 33 PM](https://github.com/javalent/dice-roller/assets/11547509/2a319770-af44-4cfe-83d1-ac58109613fc)


## Testing
- Tested locally with Obsidian 1.3.5
- Tested updating the setting correctly updates dice colors without needing to refresh

## Questions/Comments
- I'm not a designer so feel free to push back on the colors
- It would be nice to allow people to set each dice color, but I figured starting out with set colors was an okay first step
- I won't be offended if you reject the PR, this was only like 20 minutes of my life 😄 