### PR TITLE
feat: add initial display options

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -84,7 +84,7 @@ export default class API {
             shouldRender: plugin.data.renderAllDice,
             showFormula: plugin.data.displayResultsInline,
             showParens: plugin.data.displayFormulaAfter,
-            expectedValue: ExpectedValue.Roll,
+            expectedValue: plugin.data.initialDisplay,
             round: plugin.data.round,
             text: null,
             signed: plugin.data.signed

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,6 +162,8 @@ interface DiceRollerSettings {
     displayAsEmbed: boolean;
 
     round: Round;
+
+    initialDisplay: ExpectedValue;
 }
 
 export const DEFAULT_SETTINGS: DiceRollerSettings = {
@@ -188,7 +190,8 @@ export const DEFAULT_SETTINGS: DiceRollerSettings = {
     showLeafOnStartup: true,
     showDice: true,
     displayAsEmbed: true,
-    round: Round.None
+    round: Round.None,
+    initialDisplay: ExpectedValue.Roll
 };
 
 export default class DiceRollerPlugin extends Plugin {
@@ -777,7 +780,7 @@ export default class DiceRollerPlugin extends Plugin {
             options?.showFormula ?? this.data.displayResultsInline;
         let showParens = options?.showParens ?? this.data.displayFormulaAfter;
         let expectedValue: ExpectedValue =
-            options?.expectedValue ?? ExpectedValue.Roll;
+            options?.expectedValue ?? this.data.initialDisplay;
         let text: string = options?.text ?? "";
         let round = options?.round ?? this.data.round;
         let signed = options?.signed ?? this.data.signed;

--- a/src/roller/dice.ts
+++ b/src/roller/dice.ts
@@ -993,7 +993,7 @@ export class StackRoller extends GenericRoller<number> {
         public lexemes: LexicalToken[],
         showDice = plugin.data.showDice,
         fixedText: string,
-        expectedValue: ExpectedValue,
+        expectedValue = plugin.data.initialDisplay,
         displayFormulaAfter = plugin.data.displayFormulaAfter,
         round = plugin.data.round,
         signed = plugin.data.signed

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -7,7 +7,7 @@ import {
     Setting,
     TextComponent
 } from "obsidian";
-import { Round } from "src/types";
+import { Round, ExpectedValue } from "src/types";
 import { ICON_DEFINITION } from "src/utils/constants";
 import type DiceRoller from "../main";
 import { DEFAULT_SETTINGS } from "../main";
@@ -167,6 +167,18 @@ export default class SettingTab extends PluginSettingTab {
                     .setValue(this.plugin.data.round)
                     .onChange((v: Round) => {
                         this.plugin.data.round = v;
+                        this.plugin.saveSettings();
+                    });
+            });
+        new Setting(containerEl)
+            .setName("Auto Roll dice")
+            .setDesc("On initial display, should dice be rolled or displayed empty.")
+            .addDropdown((d) => {
+                d.addOption(ExpectedValue.None, "Empty")
+                 .addOption(ExpectedValue.Roll, "Rolled")
+                    .setValue(this.plugin.data.initialDisplay)
+                    .onChange((v: ExpectedValue) => {
+                        this.plugin.data.initialDisplay = v;
                         this.plugin.saveSettings();
                     });
             });


### PR DESCRIPTION
# Summary

Add an option to control whether dice rolls are initially conducted or not.  Default behavior will not change, but an option is now available to allow specifying that the dice should be displayed as empty.  This allows a default of `|none` to be propagated, so that when opening in read-mode a file the dice can start out empty until clicked.

## Anything Else?

I've added `ExpectedValue.None` and `ExpectedValue.Roll` but I didn't add `ExpectedValue.Average` as it did not seem to be appropriate for this particular functionality.
