### PR TITLE
fix: Ensure dice roller pane displays even if autodisplay is set to sempty

### DIFF
--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -12,6 +12,8 @@ import {
 import DiceRollerPlugin from "src/main";
 import { StackRoller } from "src/roller";
 import { COPY_DEFINITION, ICON_DEFINITION } from "src/utils/constants";
+import { ExpectedValue, RollerOptions } from "../types";
+import API from "../api/api";
 
 export const VIEW_TYPE = "DICE_ROLLER_VIEW";
 
@@ -238,7 +240,11 @@ export default class DiceView extends ItemView {
             return;
         }
         this.rollButton.setDisabled(true);
-        const roller = await this.plugin.getRoller(formula, "view");
+        const opts: RollerOptions = {...API.RollerOptions(this.plugin)};
+        if (opts.expectedValue == ExpectedValue.None) {
+            opts.expectedValue = ExpectedValue.Roll;
+        }
+        const roller = await this.plugin.getRoller(formula, "view", opts);
 
         if (!(roller instanceof StackRoller)) {
             new Notice("The Dice View only supports dice rolls.");


### PR DESCRIPTION
## Pull Request Description

This follows on #234.  After that PR, if the display properties were set to only display empty dice, the dice rolling pane wouldn't work, as it defaulted to *not* rolling when the dice view was added.  This checks if the display property is set not to roll (when rolling in the dice pane) and it updates to actually do the roll.  It should only impact the dice rolling view.

## Changes Proposed

<!-- List the main changes and features introduced by this pull request -->

- [ ] Override options in dice roller pane if the autodisplay is set to not roll
