### PR TITLE
fixed average

### DIFF
--- a/src/roller/dice.ts
+++ b/src/roller/dice.ts
@@ -1037,6 +1037,7 @@ export class StackRoller extends GenericRoller<number> {
                     }
                     roller.setResults(results);
                 }
+                this.calculate();
             } else {
                 this.expectedValue = ExpectedValue.Roll;
             }


### PR DESCRIPTION
## Pull Request Description

Fix average display

## Changes Proposed

Make the actual calculation of the average when it should be displayed. Otherwise, the average values of the individual dice are shown in the tooltip, but the displayed overall result is that of a random roll.

## Related Issues

Fixes part of #204

BEGIN_COMMIT_OVERRIDE
fix: Fixes average calculation
END_COMMIT_OVERRIDE