### PR TITLE
feat(dice-mod): add setting for template folder to prevent applicatio…

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -160,6 +160,16 @@
     margin: 0 6px;
 }
 
+.dice-roller-setting-additional-container
+    > .additional
+    > .setting-item
+    > .setting-item-control
+    > .dice-mod-template-use-subfolders {
+    margin: 0 px;
+    font-style: italic;
+    font-size: small;
+}
+
 .dice-roller-setting-additional-container .add-new-formula {
     margin: 0 1rem;
     padding: 1rem 1rem 0 1rem;
@@ -167,9 +177,9 @@
     box-shadow: 0 0 0.25rem var(--background-modifier-box-shadow);
 }
 
-.dice-roller-setting-additional-container
-    .add-new-formula
-    .formula-data
+.dice-roller-setting-additional-container 
+    .add-new-formula 
+    .formula-data 
     .setting-item {
     border: 0;
 }

--- a/src/live-preview.ts
+++ b/src/live-preview.ts
@@ -45,6 +45,7 @@ import {
 } from "obsidian";
 import DiceRollerPlugin from "./main";
 import { BasicRoller } from "./roller/roller";
+import { isTemplateFolder } from "./utils/util";
 
 function selectionAndRangeOverlap(
     selection: EditorSelection,
@@ -63,7 +64,7 @@ function selectionAndRangeOverlap(
 function inlineRender(view: EditorView, plugin: DiceRollerPlugin) {
     // still doesn't work as expected for tables and callouts
 
-    const currentFile = app.workspace.getActiveFile();
+    const currentFile = this.app.workspace.getActiveFile();
     if (!currentFile) return;
 
     const widgets: Range<Decoration>[] = [];
@@ -86,8 +87,19 @@ function inlineRender(view: EditorView, plugin: DiceRollerPlugin) {
                 // symbols) overlap
                 if (selectionAndRangeOverlap(selection, start, end + 1)) return;
 
+
                 const original = view.state.doc.sliceString(start, end).trim();
-                if (/^dice\-mod:\s*([\s\S]+)\s*?/.test(original)) {
+
+                const isTemplate =
+                    isTemplateFolder(
+                        plugin.data.diceModTemplateFolders,
+                        currentFile
+                    )
+                if (
+                    /^dice\-mod:\s*([\s\S]+)\s*?/.test(original) &&
+                    !isTemplate &&
+                    plugin.data.replaceDiceModInLivePreview
+                ) {
                     let [, content] = original.match(
                         /dice\-mod:\s*([\s\S]+)\s*?/
                     );
@@ -118,13 +130,12 @@ function inlineRender(view: EditorView, plugin: DiceRollerPlugin) {
                         const transaction = view.state.update({ changes: mod });
                         view.dispatch(transaction);
                     });
-
                     return;
                 }
 
-                if (!/^dice(?:\+|\-)?:\s*([\s\S]+)\s*?/.test(original)) return;
+                if (!/^dice(?:\+|\-|\-mod)?:\s*([\s\S]+)\s*?/.test(original)) return;
                 let [, content] = original.match(
-                    /^dice(?:\+|\-)?:\s*([\s\S]+)\s*?/
+                    /^dice(?:\+|\-|\-mod)?:\s*([\s\S]+)\s*?/
                 );
                 const roller = plugin.getRollerSync(content, currentFile.path);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import { inlinePlugin } from "./live-preview";
 import API from "./api/api";
 import { DEFAULT_ICONS, DiceIcon } from "./view/view.icons";
 import copy from "fast-copy";
+import { isTemplateFolder } from "./utils/util";
 /* import GenesysView, { GENESYS_VIEW_TYPE } from "./view/genesys"; */
 String.prototype.matchAll =
     String.prototype.matchAll ||
@@ -176,6 +177,9 @@ interface DiceRollerSettings {
     icons: DiceIcon[];
 
     showRenderNotice: boolean;
+    
+    diceModTemplateFolders: Record<string, boolean>;
+    replaceDiceModInLivePreview: boolean;
 }
 
 export const DEFAULT_SETTINGS: DiceRollerSettings = {
@@ -209,7 +213,9 @@ export const DEFAULT_SETTINGS: DiceRollerSettings = {
     round: Round.None,
     initialDisplay: ExpectedValue.Roll,
     icons: copy(DEFAULT_ICONS),
-    showRenderNotice: true
+    showRenderNotice: true,
+    diceModTemplateFolders: {},
+    replaceDiceModInLivePreview: true
 };
 
 export default class DiceRollerPlugin extends Plugin {
@@ -389,12 +395,17 @@ export default class DiceRollerPlugin extends Plugin {
         const modPromises: Promise<void>[] = [];
         for (let index = 0; index < nodeList.length; index++) {
             const node = nodeList.item(index);
-
+            const isTemplate =
+                isTemplateFolder(
+                    this.data.diceModTemplateFolders,
+                    file
+                )
             if (
                 file &&
                 file instanceof TFile &&
                 /^dice\-mod:\s*([\s\S]+)\s*?/.test(node.innerText) &&
-                info
+                info &&
+                !isTemplate
             ) {
                 try {
                     if (!replacementFound) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -177,7 +177,6 @@ interface DiceRollerSettings {
     icons: DiceIcon[];
 
     showRenderNotice: boolean;
-    
     diceModTemplateFolders: Record<string, boolean>;
     replaceDiceModInLivePreview: boolean;
 }
@@ -395,18 +394,15 @@ export default class DiceRollerPlugin extends Plugin {
         const modPromises: Promise<void>[] = [];
         for (let index = 0; index < nodeList.length; index++) {
             const node = nodeList.item(index);
-            const isTemplate =
-                isTemplateFolder(
-                    this.data.diceModTemplateFolders,
-                    file
-                )
+
             if (
                 file &&
                 file instanceof TFile &&
                 /^dice\-mod:\s*([\s\S]+)\s*?/.test(node.innerText) &&
-                info &&
-                !isTemplate
+                info
             ) {
+                if (isTemplateFolder(this.data.diceModTemplateFolders, file))
+                    continue;
                 try {
                     if (!replacementFound) {
                         fileContent = (
@@ -472,10 +468,7 @@ export default class DiceRollerPlugin extends Plugin {
                                 } else {
                                     splitContent = splitContent
                                         .join("\n")
-                                        .replace(
-                                            `\`${full}\``,
-                                            rep
-                                        )
+                                        .replace(`\`${full}\``, rep)
                                         .split("\n");
                                 }
 

--- a/src/suggester/folder.ts
+++ b/src/suggester/folder.ts
@@ -1,0 +1,76 @@
+import {
+    TFolder,
+    TextComponent,
+    type CachedMetadata,
+    App,
+    type FuzzyMatch
+} from "obsidian";
+import { SuggestionModal } from "./suggester";
+
+export class FolderSuggestionModal extends SuggestionModal<TFolder> {
+    text: TextComponent;
+    cache: CachedMetadata;
+    constructor(app: App, input: TextComponent, items: TFolder[]) {
+        super(app, input.inputEl, items);
+        this.text = input;
+
+        this.inputEl.addEventListener("input", () => this.getFolder());
+    }
+    getFolder() {
+        const v = this.inputEl.value,
+            folder = this.app.vault.getAbstractFileByPath(v);
+        if (folder == this.item) return;
+        if (!(folder instanceof TFolder)) return;
+        this.item = folder;
+
+        this.onInputChanged();
+    }
+    getItemText(item: TFolder) {
+        return item.path;
+    }
+    onChooseItem(item: TFolder) {
+        this.item = item;
+        this.text.setValue(item.path);
+    }
+    selectSuggestion({ item }: FuzzyMatch<TFolder>) {
+        let link = item.path;
+        this.item = item;
+        this.text.setValue(link);
+        this.onClose();
+
+        this.close();
+    }
+    renderSuggestion(result: FuzzyMatch<TFolder>, el: HTMLElement) {
+        let { item, match: matches } = result || {};
+        let content = el.createDiv({
+            cls: "suggestion-content"
+        });
+        if (!item) {
+            content.setText(this.emptyStateText);
+            content.parentElement?.addClass("is-selected");
+            return;
+        }
+
+        let pathLength = item.path.length - item.name.length;
+        const matchElements = matches.matches.map((m) => {
+            return createSpan("suggestion-highlight");
+        });
+        for (let i = pathLength; i < item.path.length; i++) {
+            let match = matches.matches.find((m) => m[0] === i);
+            if (match) {
+                let element = matchElements[matches.matches.indexOf(match)];
+                content.appendChild(element);
+                element.appendText(item.path.substring(match[0], match[1]));
+
+                i += match[1] - match[0] - 1;
+                continue;
+            }
+
+            content.appendText(item.path[i]);
+        }
+        el.createDiv({
+            cls: "suggestion-note",
+            text: item.path
+        });
+    }
+}

--- a/src/suggester/suggester.ts
+++ b/src/suggester/suggester.ts
@@ -164,6 +164,7 @@ export abstract class SuggestionModal<T> extends FuzzySuggestModal<T> {
     empty() {
         this.suggester.empty();
     }
+    shouldRender = true;
     onInputChanged(): void {
         if (this.shouldNotOpen) return;
         const inputStr = this.modifyInput(this.inputEl.value);
@@ -173,7 +174,10 @@ export abstract class SuggestionModal<T> extends FuzzySuggestModal<T> {
         } else {
             this.onNoSuggestion();
         }
-        this.open();
+        if (this.shouldRender) {
+            this.open();
+            this.shouldRender = false;
+        }
     }
     onFocus(): void {
         this.shouldNotOpen = false;

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -63,3 +63,18 @@ export function _insertIntoMap(
     /** Insert the new value at the specified index */
     map.set(index, value);
 }
+
+export function isTemplateFolder(diceModTemplateFolders: Record<string, boolean>, currentFile: TFile) {
+    return Object.entries(diceModTemplateFolders)
+        .reduce(
+            (acc, e) => {
+                let folderName: string = e[0]
+                let useSubfoldees = e[1]
+                let ret = useSubfoldees ?
+                    currentFile.parent.path.startsWith(folderName) :
+                    currentFile.parent.path == folderName
+                return acc || ret
+            },
+            false
+        )
+}

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,3 +1,4 @@
+import { TFile } from "obsidian";
 import { ResultInterface, ResultMapInterface } from "src/types";
 
 const MATCH = /^\|?([\s\S]+?)\|?$/;


### PR DESCRIPTION
…n of dice-mod in templates

add setting to prevent full application of dice-mod in live preview

## Pull Request Description
Use case:
Using a template with predefined dice-mod commands to create multiple random values, e.g.  for the next travel day (weather, encounters, etc) that can be persistently added to a adventure journal note.

## Changes Proposed

added configuration to define a folder where dice-mod templates are stored so they wont be applied prematurely.
added configuration to prevent application of dice-mod formulas in live preview edit mode (also prevents some quirks with the application of multiple dice-mod commands at once in live preview mode).

## Related Issues

---

## Checklist

- [ ] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [ ] I have added appropriate comments and documentation for the code changes.
- [ ] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [ ] All tests (if applicable) have passed successfully.
- [ ] I have run linters and fixed any issues.
- [ ] I have checked for any potential security issues or vulnerabilities.

