### PR TITLE
Update api.ts

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -241,13 +241,16 @@ class APIInstance {
         const type = this.#getTypeFromLexemes(lexemes);
         switch (type) {
             case "narrative": {
-                return new NarrativeStackRoller(
+                const roller = new NarrativeStackRoller(
                         this.data,
                         content,
                         lexemes,
                         this.app,
                         position
                     );
+
+                roller.onload(); //Retriggering onload solves the timing issue with FS rendering.
+                return roller;
             }
             case "dice": {
                 const roller = new StackRoller(


### PR DESCRIPTION
Updated narrative case in API to handle conflict with onload & FS rendering.

## Pull Request Description

Re: discord troubleshooting, narrative roller unable to produce a result  because children are populated in the onload step, which is cleared(?) when a FS statblock renders. Re-triggering the onload script solves this, though I'm not sure it's best practice. Likely would be better to move the children population to its own function and call it at the appropriate time.

## Changes Proposed

Minor changes to the narrative case in API.ts.