### PR TITLE
Update lexer.ts

### DIFF
--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -165,7 +165,7 @@ class LexerClass {
         },
         u: /u/u,
         narrative: {
-            match: /^(?:\d*(?:[GgYyBbRrPpSsWw]|[AaPpDdCcBbSsFf]|pro|boo|blk|k|sb|diff))(?: ?\d*(?:[GgYyBbRrPpSsWw]|[AaPpDdCcBbSsFf]|pro|boo|blk|k|sb|diff))+$/u,
+            match: /^(?:\d*(?!d[SF])(?:[GgYyBbRrPpSsWw]|[AaPpDdCcBbSsFf]|pro|boo|blk|k|sb|diff))(?: ?\d*(?!d[SF])(?:[GgYyBbRrPpSsWw]|[AaPpDdCcBbSsFf]|pro|boo|blk|k|sb|diff))+$/u,
             value: (match) => {
                 const isAbbr = /[AaCcDd]/.test(match);
                 return match


### PR DESCRIPTION

## Pull Request Description

Update the narrative dice regex to exclude dF and dS so as to preference stunt & fate syntax (little to no impact on actual use of narrative dice syntax).

## Changes Proposed

Minor syntax change of Narrative dice regex to preference Stunt & Fate dice.

## Related Issues

Fixes #361 #365 

